### PR TITLE
Fix 'Function foo already exists' error (rel. to #86)

### DIFF
--- a/syntax/julia.vim
+++ b/syntax/julia.vim
@@ -12,11 +12,11 @@ endif
 if version < 704
   " this is used to disable regex syntax like `\@3<='
   " on older vim versions
-  function s:d(x)
+  function! s:d(x)
     return ''
   endfunction
 else
-  function s:d(x)
+  function! s:d(x)
     return string(a:x)
   endfunction
 endif


### PR DESCRIPTION
On Ubuntu 14.4. using neovim (NVIM 0.2.0-dev) there was this error when
opening the second (or third, fourth...) Julia file:

    ...while processing ...julia-vim/syntax/julia.vim:
    line 21:
    E122: Function <SNR>104_d already exists, add ! to replace it

This commit adds '!' and fixes the error, not sure about background.