### PR TITLE
Correct indentation after if in comprehensions

### DIFF
--- a/indent/julia.vim
+++ b/indent/julia.vim
@@ -19,7 +19,7 @@ if exists("*GetJuliaIndent")
   finish
 endif
 
-let s:skipPatterns = '\<julia\%(ComprehensionFor\|RangeEnd\|CommentL\|\%([bsv]\|ip\|big\|MIME\|Shell\|Tri\|Printf\)\=String\|RegEx\|SymbolS\?\)\>'
+let s:skipPatterns = '\<julia\%(ComprehensionFor\|ComprehensionIf\|RangeEnd\|CommentL\|\%([bsv]\|ip\|big\|MIME\|Shell\|Tri\|Printf\)\=String\|RegEx\|SymbolS\?\)\>'
 
 function JuliaMatch(lnum, str, regex, st)
   let s = a:st


### PR DESCRIPTION
Currently after `if` in comprehension, e.g.:
```[x for x = y if x != z]```
an extra unnecessary indentation of the following lines is made.

It seems that adding `ComprehensionIf` to the `s:skipPatterns` solves the issue.
I am not a Vimscript expert so this PR should be checked before merging (it indents my code correctly but I might be some dependencies).