### PR TITLE
Add where and isa keyword recognition for Julia 0.6

### DIFF
--- a/syntax/julia.vim
+++ b/syntax/julia.vim
@@ -134,7 +134,11 @@ syntax region  juliaParBlockInRange	matchgroup=juliaParDelim contained start="("
 syntax region  juliaSqBraBlock		matchgroup=juliaParDelim start="\[" end="\]" contains=@juliaExpressions,juliaParBlockInRange,juliaRangeEnd,juliaComprehensionFor,juliaSymbolS,juliaQuotedParBlockS,juliaQuotedQMarkParS
 syntax region  juliaCurBraBlock		matchgroup=juliaParDelim start="{" end="}" contains=@juliaExpressions
 
-let s:keywords = '\<\%(return\|local\|global\|import\%(all\)\?\|export\|using\|const\|in\)\>'
+if b:julia_syntax_version >= 6
+  let s:keywords = '\<\%(return\|local\|global\|import\%(all\)\?\|export\|using\|const\|in\|where\|isa\)\>'
+else
+  let s:keywords = '\<\%(return\|local\|global\|import\%(all\)\?\|export\|using\|const\|in\)\>'
+endif
 
 exec 'syntax match   juliaKeyword		display "' . s:keywords . '"'
 syntax match   juliaRepKeyword		display "\<\%(break\|continue\)\>"


### PR DESCRIPTION
This PR adds `where` and `isa` to the list of keywords for Julia 0.6. `where` is a new keyword introduced for subtypes, and the function `isa` is now parsed an infix operator in the same manner as `in`. Nothing fancy is done here with regards to making sure `where` is used in an appropriate position; I figured this was good enough, at least for now.

Fixes #92 