### PR TITLE
Add highlighting recognition for `for outer`

### DIFF
--- a/syntax/julia.vim
+++ b/syntax/julia.vim
@@ -163,7 +163,14 @@ syntax match   juliaRepKeyword		display "\<\%(break\|continue\)\>"
 syntax region  juliaConditionalBlock	matchgroup=juliaConditional start="\<if\>" end="\<end\>" contains=@juliaExpressions,juliaConditionalEIBlock,juliaConditionalEBlock fold
 syntax region  juliaConditionalEIBlock	matchgroup=juliaConditional transparent contained start="\<elseif\>" end="\<\%(end\|else\|elseif\)\>"me=s-1 contains=@juliaExpressions,juliaConditionalEIBlock,juliaConditionalEBlock
 syntax region  juliaConditionalEBlock	matchgroup=juliaConditional transparent contained start="\<else\>" end="\<end\>"me=s-1 contains=@juliaExpressions
-syntax region  juliaRepeatBlock		matchgroup=juliaRepeat start="\<\%(while\|for\)\>" end="\<end\>" contains=@juliaExpressions fold
+
+if b:julia_syntax_version >= 7
+  let s:repeat_start = '\<\%(while\|for\%( outer\)\?\)\>'
+else
+  let s:repeat_start = '\<\%(while\|for\)\>'
+endif
+
+exec 'syntax region  juliaRepeatBlock		matchgroup=juliaRepeat start="' . s:repeat_start . '" end="\<end\>" contains=@juliaExpressions fold'
 syntax region  juliaBeginBlock		matchgroup=juliaBlKeyword start="\<begin\>" end="\<end\>" contains=@juliaExpressions fold
 syntax region  juliaFunctionBlock	matchgroup=juliaBlKeyword start="\<function\>" end="\<end\>" contains=@juliaExpressions fold
 syntax region  juliaMacroBlock		matchgroup=juliaBlKeyword start="\<macro\>" end="\<end\>" contains=@juliaExpressions fold


### PR DESCRIPTION
Will be introduced in https://github.com/JuliaLang/julia/pull/22659. This commit makes `outer` recognized as an annotation of sorts for `for`, such that a `juliaRepeatBlock` can start with `while`, `for`, or `for outer` if the syntax version is sufficiently new.