### PR TITLE
add R and matlab highlighting: partially working

### DIFF
--- a/syntax/julia.vim
+++ b/syntax/julia.vim
@@ -89,7 +89,7 @@ let s:operators = '\%(' . '\.\%([-+*/^÷%|&!]\|//\|\\\|<<\|>>>\?\)\?=' .
 
 syn case match
 
-syntax cluster juliaExpressions		contains=@juliaParItems,@juliaStringItems,@juliaKeywordItems,@juliaBlocksItems,@juliaTypesItems,@juliaConstItems,@juliaMacroItems,@juliaSymbolItems,@juliaOperatorItems,@juliaNumberItems,@juliaCommentItems,@juliaErrorItems
+syntax cluster juliaExpressions		contains=@juliaParItems,@juliaStringItems,@juliaKeywordItems,@juliaBlocksItems,@juliaTypesItems,@juliaConstItems,@juliaMacroItems,@juliaSymbolItems,@juliaOperatorItems,@juliaNumberItems,@juliaCommentItems,@juliaErrorItems,@juliaCodeItems
 syntax cluster juliaExprsPrintf		contains=@juliaExpressions,@juliaPrintfItems
 
 syntax cluster juliaParItems		contains=juliaParBlock,juliaSqBraBlock,juliaCurBraBlock,juliaQuotedParBlock,juliaQuotedQMarkPar
@@ -126,6 +126,7 @@ endif
 syntax cluster juliaMacroItems		contains=juliaPossibleMacro,juliaDollarVar,juliaDollarPar,juliaDollarSqBra
 syntax cluster juliaSymbolItems		contains=juliaPossibleSymbol
 syntax cluster juliaNumberItems		contains=juliaNumbers
+syntax cluster juliaCodeItems			contains=juliaRCode,juliaMatlabCode
 syntax cluster juliaStringItems		contains=juliaChar,juliaString,juliabString,juliasString,juliavString,juliaipString,juliabigString,juliaMIMEString,juliaShellString,juliaDocString,juliaRegEx
 syntax cluster juliaPrintfItems		contains=juliaPrintfParBlock,juliaPrintfString
 syntax cluster juliaOperatorItems	contains=juliaOperator,juliaRangeOperator,juliaCTransOperator,juliaTernaryRegion,juliaColon,juliaSemicolon,juliaComma
@@ -327,6 +328,11 @@ syntax region  juliaipString		matchgroup=juliaStringDelim start=+\<ip\z("\(""\)\
 syntax region  juliabigString		matchgroup=juliaStringDelim start=+\<big\z("\(""\)\?\)+ skip=+\%(\\\\\)*\\"+ end=+\z1+
 syntax region  juliaMIMEString		matchgroup=juliaStringDelim start=+\<MIME\z("\(""\)\?\)+ skip=+\%(\\\\\)*\\"+ end=+\z1+ contains=@juliaSpecialChars
 
+syntax include @juliaRSyntax syntax/r.vim
+syntax region juliaRCode matchgroup=juliaR start=+R"""+ end=+"""+ contains=@juliaRSyntax
+syntax include @juliaMatlabSyntax syntax/matlab.vim
+syntax region juliaMatlabCode matchgroup=juliaMatlab start=+mat"""+ end=+"""+ contains=@juliaMatlabSyntax
+
 syntax region  juliaDocString		matchgroup=juliaStringDelim start=+^"""+ skip=+\%(\\\\\)*\\"+ end=+"""+ contains=@juliaStringVars,@juliaSpecialChars,@juliaSpellcheckDocStrings
 
 exec 'syntax region  juliaPrintfMacro		contained transparent start="@s\?printf(" end=")\@'.s:d(1).'<=" contains=juliaMacro,juliaPrintfParBlock'
@@ -486,6 +492,8 @@ hi def link juliaComplexUnit		Constant
 
 hi def link juliaChar			Character
 
+hi def link juliaR				  String
+hi def link juliaMatlab			String
 hi def link juliaString			String
 hi def link juliabString		String
 hi def link juliasString		String


### PR DESCRIPTION
This *should* be relatively simple, and it works fine for R or matlab, but not both! - removing either `syntax include` line allows the other to work. I'm very rusty with how vim syntax highlighting works, let me know if you can see anything obvious before I just delete the matlab part and resubmit...