### PR TITLE
Fix GetJuliaIndent() messing with "ignorecase" option

### DIFF
--- a/indent/julia.vim
+++ b/indent/julia.vim
@@ -348,6 +348,8 @@ function GetJuliaIndent()
     " In case the current line starts with a closing bracket, we align it with
     " the opening one.
     if JuliaMatch(v:lnum, getline(v:lnum), '[])}]', indent(v:lnum)) == indent(v:lnum) && ind > 0
+      let &ignorecase = s:save_ignorecase
+      unlet s:save_ignorecase
       return ind - 1
     endif
 


### PR DESCRIPTION
This is a fix related to GetJuliaIndent() modifying 'ignorecase' and forgetting to set it back.

I suggest merging it for now, but in the longer term this is still not a robust solution, because if any error happens inside the indentation calculator function, the value of the option will remain disabled.

There are two possibilities:

(a) Use the equality and matching operators that are not dependent on the value of 'ignorecase', such as `==#` instead of `==` and `=~#` instead of `=~`. See [:help expr-==](http://vimdoc.sourceforge.net/htmldoc/eval.html#expr-==):

```
                use 'ignorecase'    match case	   ignore case ~
equal			==		==#		==?
not equal		!=		!=#		!=?
greater than		>		>#		>?
greater than or equal	>=		>=#		>=?
smaller than		<		<#		<?
smaller than or equal	<=		<=#		<=?
regexp matches		=~		=~#		=~?
regexp doesn't match	!~		!~#		!~?
same instance		is		is#		is?
different instance	isnot		isnot#		isnot?

Examples:
"abc" ==# "Abc"	  evaluates to 0
"abc" ==? "Abc"	  evaluates to 1
"abc" == "Abc"	  evaluates to 1 if 'ignorecase' is set, 0 otherwise
```

(b) Put all indentation calculator code inside a try-finally block. [Vim's own indentation script does this.](https://github.com/vim/vim/blob/5f73ef8d20070cd45c9aea4dc33c2e0657f5515c/runtime/indent/vim.vim#L24-L32)

Are you open to such a contribution? If so, which solution do you prefer?
