### PR TITLE
Fix misspecified supertype operator

### DIFF
--- a/syntax/julia.vim
+++ b/syntax/julia.vim
@@ -82,7 +82,7 @@ let s:binop_chars_extra = "\\U214B\\U2190-\\U2194\\U219A\\U219B\\U21A0\\U21A3\\U
 let s:idregex = '\%([^' . s:nonidS_chars . '0-9!?' . s:uniop_chars . s:binop_chars . '][^' . s:nonidS_chars . s:uniop_chars . s:binop_chars . s:binop_chars_extra . ']*\|\<?\>\)'
 
 let s:operators = '\%(' . '\.\%([-+*/^÷%|&!]\|//\|\\\|<<\|>>>\?\)\?=' .
-      \           '\|'  . '[:$<>]=\|||\|&&\||>\|<|\|<:\|:>\|::\|<<\|>>>\?\|//\|[-=]>\|\.\{3\}' .
+      \           '\|'  . '[:$<>]=\|||\|&&\||>\|<|\|<:\|>:\|::\|<<\|>>>\?\|//\|[-=]>\|\.\{3\}' .
       \           '\|'  . '[' . s:uniop_chars . '!$]' .
       \           '\|'  . '\.\?[' . s:binop_chars . s:binop_chars_extra . ']' .
       \           '\)'


### PR DESCRIPTION
Currently we're recognizing `:>` as an operator, presumably as the supertype operator, though this is actually `Symbol(">")`. The supertype operator is `>:`.