### PR TITLE
`<S-Tab>` in command mode can be enabled independently from `<Tab>`

### DIFF
--- a/autoload/LaTeXtoUnicode.vim
+++ b/autoload/LaTeXtoUnicode.vim
@@ -460,7 +460,8 @@ endfunction
 
 " Setup the L2U tab mapping
 function! s:L2U_SetTab(wait_insert_enter)
-  if !b:l2u_cmdtab_set && get(g:, "latex_to_unicode_tab", 1) && b:l2u_enabled
+  if !b:l2u_cmdtab_set && (get(g:, "latex_to_unicode_tab", 1)
+              \ || get(g:, "latex_to_unicode_shifttab", 1)) && b:l2u_enabled
     cmap <buffer> <S-Tab> <Plug>L2UCmdTab
     cnoremap <buffer> <Plug>L2UCmdTab <C-\>eLaTeXtoUnicode#CmdTab()<CR>
     let b:l2u_cmdtab_set = 1

--- a/doc/julia-vim-L2U.txt
+++ b/doc/julia-vim-L2U.txt
@@ -137,6 +137,10 @@ CTRL-V <Tab> to insert a literal <Tab>.
 The settings |g:latex_to_unicode_eager| and |g:latex_to_unicode_suggestions|
 are still meaningful in this case.
 
+If you only want to use the substitution of LaTeX sequences in command mode
+(so a mapping is only defined for <S-Tab> and not for <Tab>) you can set 
+|g:latex_to_unicode_shifttab| to 1 and |g:latex_to_unicode_tab| to 0.
+
 ------------------------------------------------------------------------------
 LATEX TO UNICODE AS YOU TYPE                    *julia-vim-L2U-as-you-type*
 


### PR DESCRIPTION
This commit adds a new option `latex_to_unicode_shifttab` that can be
used to enable `<S-Tab>` in command mode without enabling `<Tab>`
bindings.