### PR TITLE
LaTeXtoUnicode#Refresh() is not called in cmdline-window

### DIFF
--- a/ftdetect/julia.vim
+++ b/ftdetect/julia.vim
@@ -9,6 +9,7 @@ autocmd BufRead,BufNewFile *.jl      set filetype=julia
 
 autocmd FileType *                   call LaTeXtoUnicode#Refresh()
 autocmd BufEnter *                   call LaTeXtoUnicode#Refresh()
+autocmd CmdwinEnter *                call LaTeXtoUnicode#Refresh()
 
 " This autocommand is used to postpone the first initialization of LaTeXtoUnicode as much as possible,
 " by calling LaTeXtoUnicode#SetTab amd LaTeXtoUnicode#SetAutoSub only at InsertEnter or later


### PR DESCRIPTION
## Problem
LaTeXtoUnicode#Init() raises many errors in the search cmdline-window, such as:

```vim
 Error detected while processing function LaTeXtoUnicode#Init[9]..<SNR>89_L2U_UnsetTab:
 line    1:
 E121: Undefined variable: b:l2u_cmdtab_set
```

## How to reproduce
1. Open a Julia source file
1. Open the search string command-line window, press <kbd>q/</kbd>
1. Go to insert mode, press <kbd>i</kbd>
1. Errors show up!

## Solution
Call `LaTeXtoUnicode#Refresh()` before `LaTeXtoUnicode#Init()` triggered.