### PR TITLE
automatic comment insertion for single line comments

### DIFF
--- a/ftplugin/julia.vim
+++ b/ftplugin/julia.vim
@@ -22,7 +22,7 @@ setlocal fo-=t fo+=croql
 let b:julia_vim_loaded = 1
 
 let b:undo_ftplugin = "setlocal include< suffixesadd< comments< commentstring<"
-      \ . " define< shiftwidth< expandtab< indentexpr< indentkeys< cinoptions< omnifunc<"
+      \ . " define< fo< shiftwidth< expandtab< indentexpr< indentkeys< cinoptions< omnifunc<"
       \ . " | unlet! b:julia_vim_loaded"
 
 " MatchIt plugin support

--- a/ftplugin/julia.vim
+++ b/ftplugin/julia.vim
@@ -17,6 +17,7 @@ setlocal comments=:#
 setlocal commentstring=#=%s=#
 setlocal cinoptions+=#1
 setlocal define=^\\s*macro\\>
+setlocal fo-=t fo+=croql
 
 let b:julia_vim_loaded = 1
 


### PR DESCRIPTION
This PR enables automatic comment insertion in vim, i.e. when editing a comment and pressing `<CR>` or when pressing `o`, vim automatically prepends the new line with the comment character.