### PR TITLE
Use 'normal!' to avoid issues with remapped %

### DIFF
--- a/indent/julia.vim
+++ b/indent/julia.vim
@@ -315,10 +315,9 @@ function GetJuliaIndent()
     " previous line. But since we know we are still in a bracketed expression,
     " we need to find the line where the bracket was open
     elseif last_closed_bracket != -1 " && exists("loaded_matchit")
-      " we use the % command to skip back (this is buggy without matchit, and
-      " is potentially a disaster if % got remapped)
+      " we use the % command to skip back (this is buggy without matchit)
       call cursor(lnum, last_closed_bracket)
-      normal %
+      normal! %
       if line(".") == lnum
         " something wrong here, give up
         let ind = indent(lnum)


### PR DESCRIPTION
Still a hacky solution but at least a remapped `%` doesn't result in a disaster.