### PR TITLE
Fix indent when shiftwidth=0

### DIFF
--- a/indent/julia.vim
+++ b/indent/julia.vim
@@ -368,23 +368,13 @@ function GetJuliaIndent()
 
   " Analyse the reference line
   let [num_open_blocks, num_closed_blocks] = GetJuliaNestingStruct(lnum, st, lim)
-
-  " Increase indentation for each newly opened block
-  " in the reference line
-  while num_open_blocks > 0
-    let ind += &sw
-    let num_open_blocks -= 1
-  endwhile
+  " Increase indentation for each newly opened block in the reference line
+  let ind += shiftwidth() * num_open_blocks
 
   " Analyse the current line
   let [num_open_blocks, num_closed_blocks] = GetJuliaNestingStruct(v:lnum)
-
-  " Decrease indentation for each closed block
-  " in the current line
-  while num_closed_blocks > 0
-    let ind -= &sw
-    let num_closed_blocks -= 1
-  endwhile
+  " Decrease indentation for each closed block in the current line
+  let ind -= shiftwidth() * num_closed_blocks
 
   return ind
 endfunction


### PR DESCRIPTION
When `'shiftwidth'` is zero, `'ts'` should be used instead. Use `shiftwidth()`
instead of `&shiftwidth` to get the effective value.

This function was introduced with patch 7.3.694 in 2012, which would up
the minimum supported Vim version. If this is a problem a polyfill could
be added.