### PR TITLE
Also call Refresh on BufNew

### DIFF
--- a/ftdetect/julia.vim
+++ b/ftdetect/julia.vim
@@ -8,11 +8,12 @@ endif
 autocmd BufRead,BufNewFile *.jl      set filetype=julia
 
 autocmd FileType *                   call LaTeXtoUnicode#Refresh()
+autocmd BufNew *                     call LaTeXtoUnicode#Refresh()
 autocmd BufEnter *                   call LaTeXtoUnicode#Refresh()
 autocmd CmdwinEnter *                call LaTeXtoUnicode#Refresh()
 
 " This autocommand is used to postpone the first initialization of LaTeXtoUnicode as much as possible,
-" by calling LaTeXtoUnicode#SetTab amd LaTeXtoUnicode#SetAutoSub only at InsertEnter or later
+" by calling LaTeXtoUnicode#SetTab and LaTeXtoUnicode#SetAutoSub only at InsertEnter or later
 function! s:L2UTrigger()
   augroup L2UInit
     autocmd!


### PR DESCRIPTION
Similarly to #150, opening certain floating buffers but not entering them (e.g., if multiple are opened simultaneously as in https://github.com/nvim-lua/telescope.nvim) leads to numerous errors. Also calling `LaTeXtoUnicode#Refresh()` on `BufEnter` fixes this.

Also fixed a typo while I was at it.