### PR TITLE
Use --compile=min and --optimize=0 for documentation lookup.

### DIFF
--- a/autoload/julia/doc.vim
+++ b/autoload/julia/doc.vim
@@ -35,7 +35,7 @@ let s:NODOCPATTERN = '\C\VNo documentation found.'
 function! julia#doc#lookup(keyword, ...) abort
   let juliapath = get(a:000, 0, g:julia#doc#juliapath)
   let keyword = escape(a:keyword, '"\')
-  let cmd = printf('%s -E "@doc %s"', juliapath, keyword)
+  let cmd = printf('%s --compile=min --optimize=0 -E "@doc %s"', juliapath, keyword)
   return systemlist(cmd)
 endfunction
 
@@ -236,7 +236,7 @@ endfunction
 function! s:likely(str) abort
   " escape twice
   let str = escape(escape(a:str, '"\'), '"\')
-  let cmd = printf('%s -E "%s(\"%s\")"', g:julia#doc#juliapath, s:REPL_SEARCH, str)
+  let cmd = printf('%s --compile=min --optimize=0 -E "%s(\"%s\")"', g:julia#doc#juliapath, s:REPL_SEARCH, str)
   let output = systemlist(cmd)
   return split(matchstr(output[0], '\C^search: \zs.*'))
 endfunction


### PR DESCRIPTION
Use `--compile=min` and `--optimize=0` for documentation lookup. Cuts lookup time in half and makes it noticeably snappier.

Some example timings:
```
$ time julia -E '@doc sum' > /dev/null 

real    0m0.260s
user    0m0.328s
sys     0m0.140s

$ time julia --compile=min -E '@doc sum' > /dev/null                         

real    0m0.160s
user    0m0.102s
sys     0m0.070s

$ time julia --compile=min --optimize=0 -E '@doc sum' > /dev/null 

real    0m0.123s
user    0m0.077s
sys     0m0.072s
```