### PR TITLE
Allow any number of spaces in `abstract type` and `primitive type`

### DIFF
--- a/syntax/julia.vim
+++ b/syntax/julia.vim
@@ -146,8 +146,8 @@ exec 'syntax region  juliaCatchBlock		matchgroup=juliaException transparent cont
 exec 'syntax region  juliaFinallyBlock	matchgroup=juliaException transparent contained start="'.s:nodot.'\<finally\>" end="'.s:nodot.'\<end\>"me=s-1 contains=@juliaExpressions'
 exec 'syntax match   juliaTypedef		"'.s:nodot.'\<\%(abstract\|typealias\|bitstype\)\>"'
 " AbstractBlock needs to come after to take precedence
-exec 'syntax region  juliaAbstractBlock	matchgroup=juliaBlKeyword start="'.s:nodot.'\<abstract type\>" end="'.s:nodot.'\<end\>" fold contains=@juliaExpressions'
-exec 'syntax region  juliaPrimitiveBlock	matchgroup=juliaBlKeyword start="'.s:nodot.'\<primitive type\>" end="'.s:nodot.'\<end\>" fold contains=@juliaExpressions'
+exec 'syntax region  juliaAbstractBlock	matchgroup=juliaBlKeyword start="'.s:nodot.'\<abstract\s\+type\>" end="'.s:nodot.'\<end\>" fold contains=@juliaExpressions'
+exec 'syntax region  juliaPrimitiveBlock	matchgroup=juliaBlKeyword start="'.s:nodot.'\<primitive\s\+type\>" end="'.s:nodot.'\<end\>" fold contains=@juliaExpressions'
 
 exec 'syntax region  juliaComprehensionFor	matchgroup=juliaComprehensionFor transparent contained start="\%([^[:space:],;:({[]\_s*\)\@'.s:d(80).'<=\<for\>" end="\ze[]);]" contains=@juliaExpressions,juliaComprehensionIf,juliaComprehensionFor'
 exec 'syntax match   juliaComprehensionIf	contained "'.s:nodot.'\<if\>"'


### PR DESCRIPTION
The regular expressions should accept more than a single space in `abstract type` and `primitive type` since they still parse correctly. I came across this in HDF5.jl where extra space was used to line up some names:
```julia
abstract  type Hmpih end
primitive type Hmpih32 <: Hmpih 32 end
primitive type Hmpih64 <: Hmpih 64 end
```


Before:
![image](https://user-images.githubusercontent.com/2965436/95609534-73a18e00-0a24-11eb-9a31-e33b01f3b05e.png)

After:
![image](https://user-images.githubusercontent.com/2965436/95609549-7ac89c00-0a24-11eb-97f1-b90ee71ce10d.png)
