### PR TITLE
add `g:latex_to_unicode_file_types_backspaced`

### DIFF
--- a/autoload/LaTeXtoUnicode.vim
+++ b/autoload/LaTeXtoUnicode.vim
@@ -80,7 +80,12 @@ function! s:L2U_SetupGlobal()
   " A hack to forcibly get out of completion mode: feed
   " this string with feedkeys()
   if has("win32") || has("win64")
-    let s:l2u_esc_sequence = "\u0006"
+    let file_types_backspaced = s:L2U_file_type_regex(get(g:, "latex_to_unicode_file_types_backspaced", ""))
+    if match(&filetype, file_types_backspaced) >= 0 
+      let s:l2u_esc_sequence = "\u0006\b"
+    else
+      let s:l2u_esc_sequence = "\u0006"
+    endif
   else
     let s:l2u_esc_sequence = "\u0091\b"
   end

--- a/doc/julia-vim-L2U.txt
+++ b/doc/julia-vim-L2U.txt
@@ -227,6 +227,11 @@ To make it active only on, say, Julia and Lisp files, you could use:
     let g:latex_to_unicode_file_types = ["julia", "lisp"]
 <
 
+If you encounter an error (#204) where the LaTeX-to-Unicode substitutions
+add an extra control character after completion, you can use the variable
+|g:latex_to_unicode_file_types_backspaced| to specify file types for which
+you need to delete the character, similarly as above.
+
 Another option, |g:latex_to_unicode_file_types_blacklist|, can be used to
 exclude certain file types. For example, if you'd wish to enable the feature
 in all cases except for Python and untyped files, you would use:
@@ -347,6 +352,16 @@ g:latex_to_unicode_file_types
                 By default, its value is `"julia"`. The patterns provided must
                 match the whole filetype name. See also
                 |g:latex_to_unicode_file_types_blacklist|.
+
+                                            *g:latex_to_unicode_file_types_backspaced*
+g:latex_to_unicode_file_types_backspaced
+
+                Same as |g:latex_to_unicode_file_types|, but specifies certain
+                filetypes on which the escape sequence used after the LaTeX to
+                Unicode conversion has an additional backspace. This is 
+                because text-based/custom files on some systems add an extra 
+                control character after completion; this sequence deletes it.
+                By default, it contains no patterns.
 
                                   *g:latex_to_unicode_file_types_blacklist*
 g:latex_to_unicode_file_types_blacklist


### PR DESCRIPTION
I started #204 some time ago and only now got the courage to submit a PR for it.  I use the L2U functionality a lot, and it's, in my opinion, the most complete/useful of the latex-unicode conversion plugins.  So I use it for taking notes for math/physics classes.

However, I've noticed that on Windows (or at least, on my specific system?), the completion adds an extraneous control character when feeding keys to break out of completion mode.  This occurs on plaintext files, empty buffers, and some custom syntax files.

This change adds a global variable, `g:latex_to_unicode_file_types_backspaced`, which is a list of file types in which the escape sequence after tab completion has a backspace appended to it.  This erases the extra character.  By default, this is not enabled for any files.

It's evident that I'm probably one of the only people who has encountered this problem, but there isn't too much code to write to provide a preliminary fix in case someone does come and corroborate the issue.