### PR TITLE
Multiline comments

### DIFF
--- a/ftplugin/julia.vim
+++ b/ftplugin/julia.vim
@@ -13,7 +13,7 @@ set cpo-=C
 
 setlocal include=^\\s*\\%(reload\\\|include\\)\\>
 setlocal suffixesadd=.jl
-setlocal comments=:#
+setlocal comments=nfs:#=,nfe:=#,:#
 setlocal commentstring=#=%s=#
 setlocal cinoptions+=#1
 setlocal define=^\\s*macro\\>


### PR DESCRIPTION
Proper highlighting etc. of comments like these:

```julia
x=2
#=
comment explaining the code
more comments
=#
y=2x
```