### PR TITLE
Add syntax highlighting to boadcast function

### DIFF
--- a/syntax/julia.vim
+++ b/syntax/julia.vim
@@ -32,11 +32,11 @@ let s:julia_highlight_operators = get(g:, "julia_highlight_operators", 1)
 " characters which cannot be used in identifiers. This list is very incomplete:
 " 1) it only cares about charactes below 256
 " 2) it doesn't distinguish between what's allowed as the 1st char vs in the
-"    rest of an identifier (e.g. digits and `!`)
+"    rest of an identifier (e.g. digits `.` and `!`)
 " Despite these shortcomings, it seems to do a decent job.
 " note: \U5B and \U5D are '[' and ']'
 let s:nonid_chars = "\U01-\U07" . "\U0E-\U1F" .
-      \             "?\"#$'(,.:;=@`\\U5B{" .
+      \             "?\"#$'(,:;=@`\\U5B{" .
       \             "\U80-\UA1" . "\UA7\UA8\UAB\UAD\UAF\UB4" . "\UB6-\UB8" . "\UBB\UBF"
 
 let s:nonidS_chars = "[:space:])\\U5D}" . s:nonid_chars
@@ -60,7 +60,7 @@ let s:binop_chars = "=+\\U2D*/\\%÷^&|⊻<>≤≥≡≠≢∈∉⋅×∪∩⊆�
 let s:binop_chars_extra = "\\U214B\\U2190-\\U2194\\U219A\\U219B\\U21A0\\U21A3\\U21A6\\U21AE\\U21CE\\U21CF\\U21D2\\U21D4\\U21F4-\\U21FF\\U2208-\\U220D\\U2213\\U2214\\U2217-\\U2219\\U221D\\U2224-\\U222A\\U2237\\U2238\\U223A\\U223B\\U223D\\U223E\\U2240-\\U228B\\U228D-\\U229C\\U229E-\\U22A3\\U22A9\\U22AC\\U22AE\\U22B0-\\U22B7\\U22BB-\\U22BD\\U22C4-\\U22C7\\U22C9-\\U22D3\\U22D5-\\U22ED\\U22F2-\\U22FF\\U25B7\\U27C8\\U27C9\\U27D1\\U27D2\\U27D5-\\U27D7\\U27F0\\U27F1\\U27F5-\\U27F7\\U27F7\\U27F9-\\U27FF\\U2900-\\U2918\\U291D-\\U2920\\U2944-\\U2970\\U29B7\\U29B8\\U29BC\\U29BE-\\U29C1\\U29E1\\U29E3-\\U29E5\\U29F4\\U29F6\\U29F7\\U29FA\\U29FB\\U2A07\\U2A08\\U2A1D\\U2A22-\\U2A2E\\U2A30-\\U2A3D\\U2A40-\\U2A45\\U2A4A-\\U2A58\\U2A5A-\\U2A63\\U2A66\\U2A67\\U2A6A-\\U2AD9\\U2ADB\\U2AF7-\\U2AFA\\U2B30-\\U2B44\\U2B47-\\U2B4C\\UFFE9-\\UFFEC"
 
 " a Julia identifier, sort of
-let s:idregex = '\%([^' . s:nonidS_chars . '0-9!' . s:uniop_chars . s:binop_chars . '][^' . s:nonidS_chars . s:uniop_chars . s:binop_chars . s:binop_chars_extra . ']*\)'
+let s:idregex = '\%([^' . s:nonidS_chars . '0-9!.' . s:uniop_chars . s:binop_chars . '][^' . s:nonidS_chars . s:uniop_chars . s:binop_chars . s:binop_chars_extra . ']*\)'
 
 let s:operators = '\%(' . '\.\%([-+*/^÷%|&!]\|//\|\\\|<<\|>>>\?\)\?=' .
       \           '\|'  . '[:$<>]=\|||\|&&\||>\|<|\|<:\|>:\|::\|<<\|>>>\?\|//\|[-=]>\|\.\{3\}' .

--- a/syntax/julia.vim
+++ b/syntax/julia.vim
@@ -63,7 +63,7 @@ let s:binop_chars_extra = "\\U214B\\U2190-\\U2194\\U219A\\U219B\\U21A0\\U21A3\\U
 let s:idregex = '\%([^' . s:nonidS_chars . '0-9!.' . s:uniop_chars . s:binop_chars . '][^' . s:nonidS_chars . s:uniop_chars . s:binop_chars . s:binop_chars_extra . ']*\)'
 
 let s:operators = '\%(' . '\.\%([-+*/^÷%|&!]\|//\|\\\|<<\|>>>\?\)\?=' .
-      \           '\|'  . '[:$<>]=\|||\|&&\||>\|<|\|<:\|>:\|::\|<<\|>>>\?\|//\|[-=]>\|\.\{3\}' .
+      \           '\|'  . '[:$<>]=\|||\|&&\|.!\||>\|<|\|<:\|>:\|::\|<<\|>>>\?\|//\|[-=]>\|\.\{3\}' .
       \           '\|'  . '[' . s:uniop_chars . '!$]' .
       \           '\|'  . '\.\?[' . s:binop_chars . s:binop_chars_extra . ']' .
       \           '\)'


### PR DESCRIPTION
Proper syntax highlighting for broadcast function (currently dot-syntax is not recognized as function name), e.g.:
```julia
occursin.(r"^[0-9]",df[:Result])
.![true,false]
```
Note, in order to see these changes, you have to enable function and operator highlighting. This can be done, for example, by creating a file `~/.vim/after/syntax/julia.vim` containing the following lines:
````vim
" Highlight function
:hi link juliaFunctionCall Identifier
" Highlight Operators in red
:hi Operator guifg=Red ctermfg=Red
````

