### PR TITLE
Revised install instructions for Vim package management

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -51,7 +51,7 @@ git clone git://github.com/JuliaEditorSupport/julia-vim.git
 
 ### Using built-in package management
 
-Load plugin on Vim startup:
+Load plugin on Vim startup (see `:help packages`):
 
 ```bash
 cd ~/.vim

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,7 +37,7 @@ Run `vim` and update your bundles:
 ### Using [pathogen]
 
 (Note: if you are on Vim 8 or later you may as well use the built-in package management instead of
-pathogen, `:help packages`.)
+pathogen)
 
 ```bash
 cd ~/.vim
@@ -49,11 +49,18 @@ git clone git://github.com/JuliaEditorSupport/julia-vim.git
 [vundle]: https://github.com/gmarik/vundle
 [vim-plug]: https://github.com/junegunn/vim-plug
 
+### Using built-in package management
+
+Load plugin on Vim startup:
+
+```bash
+cd ~/.vim
+mkdir -p pack/plugins/start && cd pack/plugins/start
+git clone git://github.com/JuliaEditorSupport/julia-vim.git
+```
+
 ### Manually
 
-**It is advised not to use manual installation** unless you use the built-in package managment of
-Vim version 8 or later, see `:help packages`.
-
-Otherwise, since julia-vim follows the standard runtime path structure, you can copy (or symlink)
+**It is advised not to use manual installation.** Since julia-vim follows the standard runtime path structure, you can copy (or symlink)
 the relevant portions of this repository into the vim application support directory (`~/.vim` or
 `~/.config/nvim` or whatever your system uses), as appropriate.


### PR DESCRIPTION
Added install instructions for built-in Vim package management. I think it is more user friendly to directly copy listed instructions instead of reading full paragraph in `:help packages`, since the directory structure required by the package management to recognize julia-vim is not exactly intuitive. :)

_(Note: this is a direct duplicate of #217. I deleted the repository so I couldn't push new changes there. Sorry for the mess.)_