### PR TITLE
handle edge case in L2U_SetFallbackMapping in which rhs key is missing

### DIFF
--- a/autoload/LaTeXtoUnicode.vim
+++ b/autoload/LaTeXtoUnicode.vim
@@ -344,7 +344,7 @@ endfunction
 " be reinstated if needed.
 function! s:L2U_SetFallbackMapping(s, k)
   let mmdict = maparg(a:s, 'i', 0, 1)
-  if empty(mmdict)
+  if empty(mmdict) || !has_key(mmdict, "rhs")
     exe 'inoremap <buffer> ' . a:k . ' ' . a:s
     return mmdict
   endif


### PR DESCRIPTION
I think this fixes #301 in which a key mapping dictionary in the function `L2U_SetFallbackMapping` is missing the expected key `"rhs"`.  This dictionary is evidently the result of a call to the built-in function `maparg` which is supposed to return a dictionary with a set of keys including `"rhs"`.  It might be that recent versions of neovim are breaking this by failing to guarantee that all keys are present, who knows.

I'm less than 100% confident this fixes the error I was seeing (I was never able to come up with an MWE) but so far so good.  If I see the error again after this change I will of course update this thread.